### PR TITLE
Fix for bug # 361 - Responsiveness Issue

### DIFF
--- a/src/tiny-slider.js
+++ b/src/tiny-slider.js
@@ -1423,7 +1423,7 @@ export var tns = function(options) {
       updateLiveRegion();
     }
 
-    if (itemsChanged || !carousel) { updateGallerySlidePositions(); }
+    if (itemsChanged && !carousel) { updateGallerySlidePositions(); }
 
     if (!disable && !freeze) {
       // non-meduaqueries: IE8


### PR DESCRIPTION
Changed '||' to '&&' to fix issue with responsiveness when page is resized below a breakpoint; Bug relating to https://github.com/ganlanyuan/tiny-slider/issues/361