### PR TITLE
ResizeTasks errors in Safari

### DIFF
--- a/src/tiny-slider.js
+++ b/src/tiny-slider.js
@@ -1429,7 +1429,7 @@ export var tns = function(options) {
       // non-meduaqueries: IE8
       if (bpChanged && !CSSMQ) {
         // middle wrapper styles
-        if (autoHeight !== autoheightTem || speed !== speedTem) {
+        if (autoHeight !== autoHeightTem || speed !== options.speed) {
           update_carousel_transition_duration();
         }
 


### PR DESCRIPTION
Fixed errors in Safari:
camelCase issue for autoheightTem(autoHeightTem); 
Variable speedTem wasn't defined in function resizeTasks() - changed to reference options.speed